### PR TITLE
[转移到 3.1-dev]  请求超时时，status应为408 ，不应被覆盖重置为0

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -135,7 +135,9 @@ define(
                     // 因此事先去掉处理函数，然后直接进入**rejected**状态
                     xhr.onreadystatechange = null;
                     xhr.abort();
-                    !fakeXHR.status && (fakeXHR.status = 0);
+                    if (!fakeXHR.status) {
+                        fakeXHR.status = 0;
+                    }
                     fakeXHR.readyState = xhr.readyState;
                     fakeXHR.responseText = '';
                     fakeXHR.responseXML = '';


### PR DESCRIPTION
failure的 handler中 通过status来判断是否为超时错误
