### PR TITLE
修复View中getTemplateData方法解析属性路径不正确的问题

### DIFF
--- a/src/View.js
+++ b/src/View.js
@@ -81,7 +81,7 @@ define(
             }
 
             var visit = function (propertyPath) {
-                var path = propertyPath.split('.');
+                var path = propertyPath.replace(/\[(\d+)\]/g, '.$1').split('.');
                 var propertyName = path.shift();
                 var value = model.get(propertyName);
 


### PR DESCRIPTION
View.getTemplateData方法的visit函数对于属性路径为'foo.bar[0].baz.qux[1]'这样形式的数据无法正确获取，而etpl是支持通过数组下标方式传入数据的，故需修复此问题
