### PR TITLE
预防Model和View中原型上有引用类型属性因共享修改导致的问题

### DIFF
--- a/src/Model.js
+++ b/src/Model.js
@@ -196,6 +196,10 @@ define(
             this.store = {};
             this.pendingWorkers = [];
 
+            // 如果prototype上的属性是引用类型，则复制一份，
+            // 防止因共享修改导致的问题
+            util.cloneProtoProperty(this, 'datasource');
+
             if (context) {
                 this.fill(context, SILENT);
             }

--- a/src/View.js
+++ b/src/View.js
@@ -26,6 +26,12 @@ define(
         var exports = {};
 
         exports.constructor = function () {
+
+            // 如果prototype上的属性是引用类型，则复制一份，
+            // 防止因共享修改导致的问题
+            util.cloneProtoProperty(this, 'uiProperties');
+            util.cloneProtoProperty(this, 'uiEvents');
+
             this.initialize();
         };
 

--- a/src/util.js
+++ b/src/util.js
@@ -189,8 +189,7 @@ define(
         };
 
         /**
-         * 复制property上的属性
-         * 只有当前属性和原型上的属性全等才clone一份
+         * 复制prototype上的引用类型属性
          * 防止操作修改了原型上的内容 导致类型共享
          *
          * @param  {Object} context 对象
@@ -199,18 +198,17 @@ define(
         util.cloneProtoProperty = function (context, proKey) {
 
             /* eslint-disable */
-            var proValue = (context.__proto__ || context.constructor.prototype)[proKey];
+            var proValue = context[proKey];
             /* eslint-enable */
 
-            if (proValue && context[proKey] === proValue) {
-                if (typeof proValue === 'object') {
-                    context[proKey] = util.isArray(proValue)
-                                        ? proValue.slice()
-                                        : util.mix({}, proValue);
-                }
-                else  {
-                    context[proKey] = proValue;
-                }
+            if (!context.hasOwnProperty(proKey)
+                && proValue
+                && typeof proValue === 'object') {
+
+                context[proKey] = util.isArray(proValue)
+                                    ? proValue.slice()
+                                    : util.mix({}, proValue);
+
             }
         };
 

--- a/src/util.js
+++ b/src/util.js
@@ -182,6 +182,38 @@ define(
             return element;
         };
 
+        util.isArray = function (target) {
+            return (Array.isArray
+                        ? Array.isArray(target)
+                        : Object.prototype.toString.call(target) === '[object Array]');
+        };
+
+        /**
+         * 复制property上的属性
+         * 只有当前属性和原型上的属性全等才clone一份
+         * 防止操作修改了原型上的内容 导致类型共享
+         *
+         * @param  {Object} context 对象
+         * @param  {string} proKey 属性名
+         */
+        util.cloneProtoProperty = function (context, proKey) {
+
+            /* eslint-disable */
+            var proValue = (context.__proto__ || context.constructor.prototype)[proKey];
+            /* eslint-enable */
+
+            if (proValue && context[proKey] === proValue) {
+                if (typeof proValue === 'object') {
+                    context[proKey] = util.isArray(proValue)
+                                        ? proValue.slice()
+                                        : util.mix({}, proValue);
+                }
+                else  {
+                    context[proKey] = proValue;
+                }
+            }
+        };
+
         return util;
     }
 );

--- a/test/spec/util.spec.js
+++ b/test/spec/util.spec.js
@@ -96,23 +96,6 @@ define(function() {
 
         });
 
-        describe('`mix` method', function() {
-            it('should return the same object C', function() {
-                var a = {
-                    "a": 1
-                },
-                b = {
-                    "b" : 2
-                },
-                c = {
-                    "a" : 1,
-                    "b" : 2
-                };
-                expect(util.mix(a, b)).toEqual(c);
-                expect(util.mix(a, b)).not.toBe(c);
-            });
-        });
-
         describe('`bind` method', function() {
             it('should accept  a function', function() {
                 expect(function() { util.bind(function(){}) }).not.toThrow();

--- a/test/spec/util.spec.js
+++ b/test/spec/util.spec.js
@@ -1,6 +1,6 @@
 define(function() {
     var util = require('er/util');
-    
+
     describe('util', function() {
         it('should export `guid` method', function() {
             expect(util.guid).toBeOfType('function');
@@ -33,7 +33,7 @@ define(function() {
         });
         describe('`mix` method', function() {
             it('should return the same object C', function() {
-                var a = { 
+                var a = {
                     "a": 1
                 },
                 b = {
@@ -47,13 +47,78 @@ define(function() {
                 expect(util.mix(a, b)).not.toBe(c);
             });
         });
-        
+
+        describe('`isArray` method', function () {
+            it('should be judge isArray', function () {
+                expect(util.isArray([])).toEqual(true);
+                expect(util.isArray({})).not.toBe(true);
+                expect(util.isArray(1)).not.toBe(true);
+                expect(util.isArray('111')).not.toBe(true);
+            });
+        });
+
+        describe('`cloneProtoProperty` method', function () {
+            it('object property clone not exists', function () {
+
+                function A() {}
+
+                A.prototype.a = {};
+
+                var instance = new A();
+                util.cloneProtoProperty(instance, 'a');
+                expect(instance.a === instance.constructor.prototype.a).toEqual(false);
+            });
+
+            it('object property clone exists', function () {
+
+                function A() {
+                    this.a = {a: 1};
+                }
+
+                A.prototype.a = {};
+
+                var instance = new A();
+                util.cloneProtoProperty(instance, 'a');
+                expect(instance.a.a === 1).toBeTruthy();
+            });
+
+            it('array property clone', function () {
+
+                function A() {}
+
+                A.prototype.a = [];
+
+                var instance = new A();
+                util.cloneProtoProperty(instance, 'a');
+                expect(instance.a === instance.constructor.prototype.a).toEqual(false);
+                expect(util.isArray(instance.a)).toBeTruthy();
+            });
+
+        });
+
+        describe('`mix` method', function() {
+            it('should return the same object C', function() {
+                var a = {
+                    "a": 1
+                },
+                b = {
+                    "b" : 2
+                },
+                c = {
+                    "a" : 1,
+                    "b" : 2
+                };
+                expect(util.mix(a, b)).toEqual(c);
+                expect(util.mix(a, b)).not.toBe(c);
+            });
+        });
+
         describe('`bind` method', function() {
             it('should accept  a function', function() {
                 expect(function() { util.bind(function(){}) }).not.toThrow();
             });
         });
-        
+
         describe('`inherits` method', function() {
             it('classA should be inherit superClassA', function() {
                 function SuperClassA() {}


### PR DESCRIPTION
预防Model和View中原型上有引用类型属性因共享修改导致的问题